### PR TITLE
feat: add synthesis prompt MD export button and improve synthesis prompt quality

### DIFF
--- a/examples/hermes-export-example.json
+++ b/examples/hermes-export-example.json
@@ -1,0 +1,391 @@
+{
+  "exportedAt": "2026-03-11T08:00:00.000Z",
+  "appVersion": "1.2.2",
+  "briefingCount": 2,
+  "synthesisCount": 1,
+  "briefings": [
+    {
+      "id": "2026-03-09",
+      "date": "March 9, 2026",
+      "system_status": {
+        "condition": "ELEVATED",
+        "indicator": "VOLATILE"
+      },
+      "today_in_60_seconds": [
+        {
+          "id": "story-energy-hormuz",
+          "icon": "🛢️",
+          "headline": "Oil volatility spikes following unconfirmed drone activity",
+          "domain": "ENERGY",
+          "summary": "Brent crude briefly crossed $100 before reversing. Options flows suggest traders are aggressively repricing tail-risk for maritime supply chain interruptions over the next 48 hours.",
+          "signal_type": "SIGNAL_SHIFT",
+          "status": "ESCALATING",
+          "target": "Strait of Hormuz",
+          "metric": "+17.1% VOL"
+        },
+        {
+          "id": "story-global-rates",
+          "icon": "📉",
+          "headline": "Markets reprice inflation risk path",
+          "domain": "MACRO",
+          "signal_type": "CONTINUING_SIGNAL",
+          "status": "VOLATILE",
+          "target": "Front-End Yields",
+          "metric": "REPRICING"
+        },
+        {
+          "id": "story-sovereign-ai-compute",
+          "icon": "🤖",
+          "headline": "China accelerates sovereign compute infrastructure",
+          "domain": "TECH",
+          "signal_type": "CONTINUING_SIGNAL",
+          "status": "HIGH",
+          "target": "Domestic Datacenters",
+          "metric": "CAPEX SURGE"
+        },
+        {
+          "id": "story-pentagon-ai-governance",
+          "icon": "⚖️",
+          "headline": "Pentagon-AI governance friction delays deployments",
+          "domain": "DEFENSE",
+          "signal_type": "SIGNAL_SHIFT",
+          "status": "MONITOR",
+          "target": "Autonomous Systems",
+          "metric": "DELAYED"
+        },
+        {
+          "id": "story-ecb-rate-path",
+          "icon": "🌍",
+          "headline": "ECB signals hawkish hold on rate cuts",
+          "domain": "MACRO",
+          "signal_type": "SIGNAL_SHIFT",
+          "status": "STABILIZING",
+          "target": "EUR/USD",
+          "metric": "HAWKISH"
+        }
+      ],
+      "what_changed": {
+        "new": [
+          "War-risk insurance costs jumped again for Gulf-linked commercial shipping routes.",
+          "ECB messaging hardened around the risk of energy-led inflation persistence."
+        ],
+        "escalating": [
+          "Oil volatility is now feeding directly into front-end rate pricing and cross-asset hedging.",
+          "Competition for sovereign AI capacity is expanding from technology policy into energy and industrial planning."
+        ],
+        "de_escalating": [
+          "The most acute fear of a full maritime halt eased after some vessels resumed rerouted passage."
+        ],
+        "watch": [
+          "Whether Hormuz transit volumes normalise or deteriorate over the next 24 hours.",
+          "Any central bank statement that explicitly links energy volatility to rate path revision."
+        ]
+      },
+      "major_developments": [
+        {
+          "id": "dev-1",
+          "story_id": "story-energy-hormuz",
+          "domain": "ENERGY",
+          "region": "MIDDLE EAST",
+          "impact": "CRITICAL",
+          "icon": "🛢️",
+          "driver": "Unconfirmed drone activity near Gulf shipping lanes triggered war-risk repricing and forced rerouting decisions.",
+          "change_type": "escalating",
+          "story_stage": "peak",
+          "headline": "Oil Shock and War Risk",
+          "why_it_matters_now": "The disruption is now materially altering inflation expectations, shipping costs, and central-bank path assumptions.",
+          "executive_summary": "Oil surged nearly 30% before reversing as geopolitical tensions escalated and maritime risk began transmitting into macro pricing.",
+          "key_facts": [
+            "Brent briefly crossed $100 before retracing as traders digested mixed security signals.",
+            "Insurers widened Gulf transit premiums, lifting shipping costs within hours.",
+            "Volatility spread from energy into rates, equities, and FX positioning."
+          ],
+          "next_watchpoints": [
+            "Commercial vessel transit volumes through the Strait of Hormuz over the next 24 hours.",
+            "Whether regional actors issue credible de-escalation signals or expand interdiction risk."
+          ],
+          "tags": ["energy", "shipping", "oil", "inflation", "middle-east"],
+          "sources": [
+            { "name": "Reuters", "url": "https://www.reuters.com/world/middle-east/" },
+            { "name": "Bloomberg", "url": "https://www.bloomberg.com/energy" }
+          ]
+        },
+        {
+          "id": "dev-2",
+          "story_id": "story-global-rates",
+          "domain": "MACRO",
+          "region": "GLOBAL",
+          "impact": "HIGH",
+          "icon": "📉",
+          "driver": "Energy shock is re-entering the inflation calculus, pushing rate-cut timelines further out across G7 central banks.",
+          "change_type": "escalating",
+          "story_stage": "active",
+          "headline": "Inflation Path Repriced",
+          "why_it_matters_now": "This has shifted from a rates debate to a cross-asset repricing event driven by geopolitical inflation risk.",
+          "executive_summary": "Bond and equity desks are resetting expectations for the timing and depth of rate cuts.",
+          "key_facts": [
+            "Front-end yields rose as inflation hedges widened after the energy shock.",
+            "FX desks repositioned around renewed dollar strength and policy divergence risk."
+          ],
+          "next_watchpoints": [
+            "Whether the next inflation prints confirm pass-through from energy into broader expectations.",
+            "Any central-bank communication that reframes the likely path of cuts."
+          ],
+          "tags": ["macro", "rates", "inflation", "fx", "policy"],
+          "sources": [
+            { "name": "Bloomberg", "url": "https://www.bloomberg.com/markets" },
+            { "name": "Financial Times", "url": "https://www.ft.com/markets" }
+          ]
+        },
+        {
+          "id": "dev-3",
+          "story_id": "story-sovereign-ai-compute",
+          "domain": "TECH",
+          "region": "GLOBAL",
+          "impact": "HIGH",
+          "icon": "🤖",
+          "driver": "Export control tightening and energy competition are forcing state actors to treat compute infrastructure as a sovereignty asset.",
+          "change_type": "escalating",
+          "story_stage": "active",
+          "headline": "Sovereign AI Compute Race",
+          "why_it_matters_now": "The story is widening from chip access into datacenter siting, energy allocation, and state-backed capital deployment.",
+          "executive_summary": "Nations are increasingly treating high-tier compute clusters as critical national infrastructure.",
+          "key_facts": [
+            "New export control proposals are tightening access to advanced accelerator supply.",
+            "Sovereign and state-linked capital is moving into domestic datacenter buildout."
+          ],
+          "next_watchpoints": [
+            "Additional export-control coordination between the US and allies.",
+            "Announcements on power allocation, permits, or domestic compute subsidies."
+          ],
+          "tags": ["ai", "compute", "industrial-policy", "chips", "state-capacity"],
+          "sources": [
+            { "name": "Wall Street Journal", "url": "https://www.wsj.com/tech" }
+          ]
+        }
+      ],
+      "analyst_consensus": {
+        "consensus": [
+          "Energy shock could delay rate cuts globally.",
+          "Defense and compute spending will remain non-cyclical."
+        ],
+        "friction": [
+          "Some analysts believe the oil spike will reverse rapidly if conflict cools.",
+          "Disagreement on whether the ECB will follow the Fed's hawkish tilt."
+        ]
+      },
+      "strategic_context": [
+        "Energy shocks are reintroducing geopolitics into macroeconomic expectations.",
+        "The intersection of AI infrastructure demands and energy scarcity is becoming the defining macroeconomic theme of the decade."
+      ],
+      "watchlist": "Strait of Hormuz shipping flows over the next 48 hours may determine whether energy volatility persists and bleeds into core inflation metrics."
+    },
+    {
+      "id": "2026-03-10",
+      "date": "March 10, 2026",
+      "system_status": {
+        "condition": "HIGH",
+        "indicator": "ESCALATING"
+      },
+      "today_in_60_seconds": [
+        {
+          "id": "story-energy-hormuz",
+          "icon": "🛢️",
+          "headline": "Hormuz transit volumes fall 18% as rerouting accelerates",
+          "domain": "ENERGY",
+          "summary": "Shipping data confirmed a material drop in Strait of Hormuz transit as major carriers completed rerouting to the Cape of Good Hope, adding 11 days of transit time and locking in cost pressure.",
+          "signal_type": "SIGNAL_SHIFT",
+          "status": "CRITICAL",
+          "target": "Strait of Hormuz",
+          "metric": "-18% TRANSIT"
+        },
+        {
+          "id": "story-global-rates",
+          "icon": "📊",
+          "headline": "Fed speakers push back on early cut expectations",
+          "domain": "MACRO",
+          "signal_type": "SIGNAL_SHIFT",
+          "status": "ESCALATING",
+          "target": "Fed Funds Rate",
+          "metric": "HAWKISH TILT"
+        },
+        {
+          "id": "story-sovereign-ai-compute",
+          "icon": "🤖",
+          "headline": "US expands chip export controls to five new jurisdictions",
+          "domain": "TECH",
+          "signal_type": "SIGNAL_SHIFT",
+          "status": "ESCALATING",
+          "target": "Semiconductor Supply Chain",
+          "metric": "NEW CONTROLS"
+        },
+        {
+          "id": "story-ecb-rate-path",
+          "icon": "🌍",
+          "headline": "ECB holds rates, flags energy pass-through risk",
+          "domain": "MACRO",
+          "signal_type": "CONTINUING_SIGNAL",
+          "status": "MONITOR",
+          "target": "Eurozone Inflation",
+          "metric": "ON HOLD"
+        }
+      ],
+      "what_changed": {
+        "new": [
+          "Shipping data confirmed the rerouting is now structural, not precautionary — transit volumes are materially down.",
+          "US announced new chip export controls expanding the list of restricted jurisdictions."
+        ],
+        "escalating": [
+          "The Hormuz disruption moved from volatility event to confirmed supply-chain shift.",
+          "Fed speakers hardened the rate-higher-for-longer narrative in response to energy-driven inflation risk."
+        ],
+        "de_escalating": [
+          "Back-channel diplomatic signals suggested limited appetite for full escalation among regional actors."
+        ],
+        "watch": [
+          "Whether OPEC+ responds to supply disruption with production increases or holds output.",
+          "Any Fed communication that explicitly ties energy pass-through to a rate-cut delay."
+        ]
+      },
+      "major_developments": [
+        {
+          "id": "dev-1",
+          "story_id": "story-energy-hormuz",
+          "domain": "ENERGY",
+          "region": "MIDDLE EAST",
+          "impact": "CRITICAL",
+          "icon": "🛢️",
+          "driver": "Confirmed rerouting by major carriers locks in shipping cost increases and removes the scenario of a rapid return to normal flows.",
+          "change_type": "escalating",
+          "story_stage": "peak",
+          "headline": "Hormuz Rerouting Confirmed as Structural",
+          "why_it_matters_now": "The shift from 'disruption risk' to 'confirmed disruption' raises the floor on energy and shipping costs for weeks, not hours.",
+          "executive_summary": "Transit volumes fell 18% as carriers completed diversions, locking in cost increases and extending supply chain timelines materially.",
+          "key_facts": [
+            "Major carriers confirmed full diversion to Cape of Good Hope routing.",
+            "Transit time increase of 11 days adds ~$2.4M per voyage in additional fuel and time costs.",
+            "Brent held above $97 as the structural nature of the disruption became clear."
+          ],
+          "next_watchpoints": [
+            "Whether OPEC+ emergency production signals emerge to cap the price spike.",
+            "Whether insurance markets reprice Gulf of Oman routes or maintain extended exclusions."
+          ],
+          "tags": ["energy", "shipping", "hormuz", "supply-chain", "oil"],
+          "sources": [
+            { "name": "Reuters", "url": "https://www.reuters.com/world/middle-east/" },
+            { "name": "Bloomberg", "url": "https://www.bloomberg.com/energy" }
+          ]
+        },
+        {
+          "id": "dev-2",
+          "story_id": "story-global-rates",
+          "domain": "MACRO",
+          "region": "UNITED STATES",
+          "impact": "HIGH",
+          "icon": "📊",
+          "driver": "Fed speakers are recalibrating the rate-cut timeline explicitly in response to energy-driven inflation persistence.",
+          "change_type": "escalating",
+          "story_stage": "active",
+          "headline": "Fed Pushes Back on Rate Cut Timeline",
+          "why_it_matters_now": "The Fed's public reframing of the rate path removes the last major soft-landing argument underpinning equity valuations.",
+          "executive_summary": "Two Fed governors cited energy-driven inflation risk as a reason to delay the first cut beyond market expectations.",
+          "key_facts": [
+            "Market pricing for the first cut shifted from June to September following Fed commentary.",
+            "2-year Treasury yields rose 14bps on the day.",
+            "Dollar index strengthened 0.8% as rate divergence expectations widened."
+          ],
+          "next_watchpoints": [
+            "The next CPI print — any energy pass-through will validate the hawkish pivot.",
+            "Whether the ECB follows with similar messaging, deepening global rate divergence."
+          ],
+          "tags": ["macro", "fed", "rates", "inflation", "yields"],
+          "sources": [
+            { "name": "Financial Times", "url": "https://www.ft.com/markets" },
+            { "name": "Bloomberg", "url": "https://www.bloomberg.com/markets" }
+          ]
+        }
+      ],
+      "analyst_consensus": {
+        "consensus": [
+          "The Hormuz disruption is now a multi-week supply chain event, not a one-day volatility spike.",
+          "Rate cuts are pushed out in the US and Europe — the soft-landing window is narrowing."
+        ],
+        "friction": [
+          "Disagreement on whether oil can hold above $95 if OPEC+ signals emergency supply increases.",
+          "Some analysts argue the Fed commentary was positioning, not a genuine policy shift."
+        ]
+      },
+      "strategic_context": [
+        "Two separate shocks — maritime security and central bank communication — are compounding into a single macro regime shift.",
+        "The energy-inflation-rates transmission channel is now fully active, with each node reinforcing the next."
+      ],
+      "watchlist": "OPEC+ response and the next Fed communication are the two pivots that will determine whether this becomes a sustained macro disruption or a sharp but contained episode."
+    }
+  ],
+  "syntheses": [
+    {
+      "type": "synthesis",
+      "id": "synth-2026-03-09-to-2026-03-10",
+      "date_range": {
+        "from": "2026-03-09",
+        "to": "2026-03-10"
+      },
+      "dominant_system": "Gulf Energy-Inflation Transmission",
+      "active_threads": [
+        {
+          "story_id": "story-energy-hormuz",
+          "title": "Hormuz Shipping Disruption",
+          "status": "active",
+          "phase": "peak",
+          "first_seen": "2026-03-09",
+          "last_seen": "2026-03-10",
+          "summary": "What began as unconfirmed drone activity escalated within 48 hours into confirmed structural rerouting, with transit volumes down 18% and shipping costs locked in for weeks. The story crossed from risk event to supply chain reality on Day 2."
+        },
+        {
+          "story_id": "story-global-rates",
+          "title": "Rate Cut Timeline Repriced",
+          "status": "active",
+          "phase": "escalation",
+          "first_seen": "2026-03-09",
+          "last_seen": "2026-03-10",
+          "summary": "Energy-driven inflation risk moved the Fed and ECB from ambiguous to explicitly hawkish over two days, pushing market pricing for the first US cut from June to September. The rate story is now downstream of the energy story."
+        },
+        {
+          "story_id": "story-sovereign-ai-compute",
+          "title": "Sovereign Compute Race",
+          "status": "active",
+          "phase": "escalation",
+          "first_seen": "2026-03-09",
+          "last_seen": "2026-03-10",
+          "summary": "New US export controls expanded the compute sovereignty contest beyond China to five additional jurisdictions, accelerating the bifurcation of the global AI infrastructure supply chain. Energy and chip access are now co-dependent constraints."
+        }
+      ],
+      "thematic_arcs": [
+        "A single maritime security event triggered a complete macro regime shift within 48 hours — energy, inflation, rates, and FX all repriced in sequence, demonstrating the full transmission chain from geopolitics to financial conditions.",
+        "The AI infrastructure race and the energy disruption are converging: sovereign compute ambitions now compete directly for the same power capacity that is being threatened by the Hormuz crisis."
+      ],
+      "delta_risks": [
+        {
+          "story_id": "story-energy-hormuz",
+          "description": "Risk escalated from tail scenario to base case — confirmed rerouting removed the rapid-normalisation path and locked in elevated shipping and energy costs for the medium term.",
+          "direction": "increasing"
+        },
+        {
+          "story_id": "story-global-rates",
+          "description": "Rate-cut risk shifted from timing uncertainty to directional reversal — the market now prices significantly fewer cuts, and the probability of a hike re-entering the conversation is non-zero.",
+          "direction": "increasing"
+        }
+      ],
+      "phase_shifts": [
+        {
+          "story_id": "story-energy-hormuz",
+          "from": "emerging",
+          "to": "peak",
+          "date": "2026-03-10",
+          "reason": "Confirmed carrier rerouting converted the disruption from a risk event to an established supply-chain fact, marking peak impact as the new baseline."
+        }
+      ],
+      "meta_findings": "This two-day period demonstrated how rapidly a single geopolitical shock can activate the full macro transmission chain: energy → inflation → central bank communication → financial conditions tightening. The speed of the transmission — from unconfirmed drone activity to confirmed Fed hawkishness in under 48 hours — suggests the current macro environment has very low shock-absorption capacity. The simultaneous escalation of the AI compute race under energy-constrained conditions adds a structural dimension that no single daily briefing captured: two of the period's biggest stories are now competing for the same scarce resource."
+    }
+  ]
+}

--- a/src/components/ThreadCard.jsx
+++ b/src/components/ThreadCard.jsx
@@ -1,12 +1,13 @@
 import { ArrowUpRight } from 'lucide-react';
 
 const PHASE_COLORS = {
-  escalation: 'text-rose-300 border-rose-500/20 bg-rose-950/20',
-  active:     'text-amber-300 border-amber-500/20 bg-amber-950/20',
-  emerging:   'text-cyan-300 border-cyan-500/20 bg-cyan-950/20',
-  peak:       'text-orange-300 border-orange-500/20 bg-orange-950/20',
-  resolution: 'text-emerald-300 border-emerald-500/20 bg-emerald-950/20',
-  default:    'text-slate-300 border-slate-500/20 bg-slate-800/20',
+  escalation:  'text-rose-300 border-rose-500/20 bg-rose-950/20',
+  active:      'text-amber-300 border-amber-500/20 bg-amber-950/20',
+  emerging:    'text-cyan-300 border-cyan-500/20 bg-cyan-950/20',
+  peak:        'text-orange-300 border-orange-500/20 bg-orange-950/20',
+  stabilising: 'text-sky-300 border-sky-500/20 bg-sky-950/20',
+  resolution:  'text-emerald-300 border-emerald-500/20 bg-emerald-950/20',
+  default:     'text-slate-300 border-slate-500/20 bg-slate-800/20',
 };
 
 function phaseColor(phase) {

--- a/src/utils/prompts.js
+++ b/src/utils/prompts.js
@@ -238,11 +238,13 @@ export function getSynthesisPrompt(fromDateStr, toDateStr, briefings) {
     .map((b) => JSON.stringify(b, null, 2))
     .join('\n\n---\n\n');
 
-  return `You are a senior strategic intelligence analyst reviewing a sequence of daily briefings. Your job is to produce a synthesis overlay — a cross-day analysis that identifies persistent story threads, narrative arcs, phase shifts, and risk deltas across the briefing period.
+  return `You are a senior strategic intelligence analyst reviewing a sequence of daily briefings produced by the Hermes intelligence system. Your job is to produce a synthesis overlay — a cross-day analytical layer that identifies persistent story threads, narrative arcs, phase shifts, and risk deltas across the briefing period.
+
+Do not re-summarise individual days. Your job is to show what the PERIOD reveals that no single briefing could.
 
 The date range you are analysing: **${fromDateStr} to ${toDateStr}**
 
-The daily briefings are appended below. Review all of them before writing your output.
+The daily briefings are appended below in full. Review all of them before writing your output.
 
 Return a single valid JSON object matching the schema below. No commentary, no markdown code fences, no explanation — only the JSON.
 
@@ -255,32 +257,26 @@ REQUIRED OUTPUT SCHEMA:
     "from": "${fromDateStr}",
     "to": "${toDateStr}"
   },
+  "dominant_system": "A short, punchy 3–7 word phrase naming the dominant geopolitical or macro system driving the period. Appears as a header label — be specific, not generic.",
   "active_threads": [
     {
-      "story_id": "story-kebab-id",
-      "title": "Human-readable story title",
+      "story_id": "story-kebab-id-matching-briefings",
+      "title": "Human-readable story title — not the story_id slug. A proper name like 'Gulf Energy Crisis' or 'Fed Pivot Uncertainty'.",
       "status": "active",
       "phase": "escalation",
       "first_seen": "YYYY-MM-DD",
       "last_seen": "YYYY-MM-DD",
-      "summary": "2–3 sentence arc summary: what this story did over the review period."
+      "summary": "Lead sentence capturing the arc across the full period. Second sentence on what drove the trajectory. The UI shows 2 lines — the first sentence must stand alone and deliver the key insight."
     }
   ],
   "thematic_arcs": [
-    "Cross-cutting structural pattern that connects multiple stories.",
-    "Second arc or system-level dynamic that emerged across the period."
-  ],
-  "story_clusters": [
-    {
-      "label": "Cluster label",
-      "story_ids": ["story-id-1", "story-id-2"],
-      "rationale": "Why these stories belong together thematically or causally."
-    }
+    "A single complete sentence naming a structural cross-domain pattern that ran through the period — not a restatement of one story.",
+    "A second arc: a different systemic dynamic connecting otherwise separate developments."
   ],
   "delta_risks": [
     {
       "story_id": "story-kebab-id",
-      "description": "How the risk profile of this story changed over the period.",
+      "description": "How the risk profile of this story materially changed over the period — focus on trajectory change, not current state.",
       "direction": "increasing"
     }
   ],
@@ -288,35 +284,47 @@ REQUIRED OUTPUT SCHEMA:
     {
       "story_id": "story-kebab-id",
       "from": "emerging",
-      "to": "active",
+      "to": "escalation",
       "date": "YYYY-MM-DD",
       "reason": "What caused the phase transition."
     }
   ],
-  "dominant_system": "One phrase naming the dominant geopolitical or macro system driving events this period.",
-  "coverage_bias": "Honest assessment of what may be underweighted or missing from the briefings reviewed.",
-  "meta_findings": "2–3 sentences on what the period reveals about the broader environment that a single daily briefing would miss."
+  "meta_findings": "2–3 sentences on what this period reveals about the broader environment that a single daily briefing would miss. This is the synthesis overlay's highest-value output — write it last, after seeing the full period pattern."
 }
 
 HARD RULES:
 
 - type must be exactly "synthesis"
 - id must follow format: synth-YYYY-MM-DD-to-YYYY-MM-DD
-- active_threads[].story_id must match story_id values from the briefings exactly — do not invent new IDs
+- active_threads[].story_id must match story_id values from the briefings exactly — do not invent or rename IDs
 - active_threads[].phase must be one of: emerging, escalation, peak, stabilising, resolution
 - active_threads[].status must be one of: active, dormant, resolved
 - delta_risks[].direction must be one of: increasing, decreasing, stable
 - phase_shifts[].from and .to must be one of: emerging, active, peak, winding-down, resolved
-- Do not overwrite or contradict the factual record of any individual daily briefing
+- dominant_system must be 3–7 words, not a full sentence
+- thematic_arcs must be plain strings, not objects
+- Do not overwrite or contradict the factual record of any individual daily briefing — the synthesis interprets across them, it does not revise them
+- Keep all string values compact — this is a mobile-first product rendered on small screens
 - Return valid JSON only. No markdown. No code fences. No commentary.
 
+DISPLAY NOTES (how the UI renders each field — write content to fit):
+
+- dominant_system: shown as a label in the top-right of the synthesis card header
+- active_threads: each renders as a card row with title (bold), phase badge (color-coded), story_id (monospace), first_seen→last_seen dates, and summary clipped to 2 lines
+  - phase badge colors: emerging=cyan, escalation=rose, peak=orange, stabilising=blue, resolution=green
+  - phase should reflect where the story stood at the END of the review period
+- thematic_arcs: rendered as a bulleted list — write as crisp single sentences
+- delta_risks: rendered as "story_id — description" with a △ marker
+- phase_shifts: rendered as "story_id: from → to" — reason is stored but not displayed in the UI
+- meta_findings: rendered as a paragraph block at the bottom of the card
+
 PRIORITISE:
-1. Thread continuity — which stories ran across multiple days and how did they evolve?
-2. Identity repair — if the same story appeared under different story_id values, note it in meta_findings
-3. Phase detection — look for stories that changed lifecycle stage
-4. Risk deltas — which risks got materially worse or better?
-5. System dominance — what single system was most structurally significant?
-6. Coverage gaps — what important dynamics were underweighted?
+1. active_threads — core output; include all stories that appeared across 2+ briefings; omit single-day flashes
+2. meta_findings — highest analytical value; write last after seeing the full period pattern
+3. dominant_system — the one system most structurally responsible for the period's dynamics
+4. thematic_arcs — cross-cutting structural patterns only; 2–4, quality over quantity
+5. delta_risks — only stories where risk trajectory materially changed direction; 2–5 items
+6. phase_shifts — only genuine transitions backed by evidence in the briefings; 1–4 items
 
 --- DAILY BRIEFINGS ---
 

--- a/src/views/WorkflowView.jsx
+++ b/src/views/WorkflowView.jsx
@@ -1,5 +1,15 @@
 import { useState, useMemo } from 'react';
-import { Copy, Check, ChevronDown, ChevronUp, ArrowRight, Zap, GitMerge, Layers } from 'lucide-react';
+import { Copy, Check, ChevronDown, ChevronUp, ArrowRight, Zap, GitMerge, Layers, Download } from 'lucide-react';
+
+function downloadFile(filename, contents, type) {
+  const blob = new Blob([contents], { type });
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(objectUrl);
+}
 import { getDailyPrompt, getAmplifierPrompt, getSynthesisPrompt } from '../utils/prompts';
 
 function useCopy(timeout = 2000) {
@@ -291,6 +301,24 @@ function SynthesisSection({ briefings, onGoToImport }) {
               No briefings in range
             </div>
           )}
+
+          <button
+            type="button"
+            onClick={() => downloadFile(
+              `hermes-synthesis-prompt-${fromDate}-to-${toDate}.md`,
+              prompt,
+              'text/markdown;charset=utf-8'
+            )}
+            disabled={!prompt}
+            className={`w-full flex items-center justify-center gap-2 py-3.5 rounded-2xl border font-bold text-[11px] font-mono uppercase tracking-[0.18em] transition-all ${
+              prompt
+                ? 'border-purple-500/30 bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 hover:border-purple-400/50'
+                : 'border-white/5 bg-white/3 text-slate-600 cursor-not-allowed'
+            }`}
+          >
+            <Download size={14} strokeWidth={2} />
+            Export Prompt as MD
+          </button>
 
           <button
             type="button"


### PR DESCRIPTION
- WorkflowView: add 'Export Prompt as MD' download button to SynthesisSection, downloads hermes-synthesis-prompt-{from}-to-{to}.md with full prompt + embedded briefings
- prompts: rewrite getSynthesisPrompt with UI-aware guidance, display notes, quantity guides, mobile-first note, removes unused story_clusters/coverage_bias from schema
- ThreadCard: add missing stabilising phase badge color (sky-blue)
- examples/hermes-export-example.json: add complete example export with 2 briefings and 1 synthesis overlay for format reference

https://claude.ai/code/session_011eJJA5PTe2Jq6ihBVDryg3