### PR TITLE
feat(sources): add Perigon News API as a third wire source (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ GUARDIAN_API_KEY=
 # NYT Developer key - https://developer.nytimes.com/
 NYT_API_KEY=
 
+# Perigon News API key (free tier) - https://www.perigon.io/
+# Widens the world/business pool beyond Guardian + NYT (aggregates FT, Reuters,
+# Bloomberg, etc.). Optional: the run skips Perigon gracefully when unset.
+PERIGON_API_KEY=
+
 # ntfy.sh topic for the morning push (pick something hard to guess)
 NTFY_TOPIC=
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GUARDIAN_API_KEY: ${{ secrets.GUARDIAN_API_KEY }}
           NYT_API_KEY: ${{ secrets.NYT_API_KEY }}
+          PERIGON_API_KEY: ${{ secrets.PERIGON_API_KEY }}
           CURATE_MODEL: ${{ vars.CURATE_MODEL }}
           PAGES_URL: ${{ vars.PAGES_URL }}
         run: python -m src.build

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 An autonomous overnight pipeline that assembles a personalized Toronto morning
 newspaper, renders it as a static web page, and pushes a notification to your
-phone at 7:00 AM. World and national news come from the Guardian and NYT APIs;
-Toronto local news comes from RSS. Google Gemini (`gemini-2.5-flash`, free
+phone at 7:00 AM. World and business news come from the Guardian, NYT, and
+Perigon APIs (Perigon aggregates FT, Reuters, Bloomberg and thousands more, so
+the business desk reads like a professional's, not just one paper); Toronto
+local news comes from RSS. Google Gemini (`gemini-2.5-flash`, free
 tier) dedupes, sections, ranks, and summarizes; a sensitivity rule keeps hard
 news text-only. The result deploys to GitHub Pages and an ntfy.sh push links
 straight to it.
@@ -22,7 +24,7 @@ weather -> fetch -> normalize -> curate (Claude) -> resolve images -> render -> 
 | Module | Role |
 |---|---|
 | [src/weather.py](src/weather.py) | Open-Meteo Toronto forecast (no key) |
-| [src/fetch.py](src/fetch.py) | Guardian + NYT APIs, Toronto RSS (graceful per-source failure) |
+| [src/fetch.py](src/fetch.py) | Guardian + NYT + Perigon APIs, Toronto RSS (graceful per-source failure) |
 | [src/normalize.py](src/normalize.py) | Unify sources into one story schema |
 | [src/curate.py](src/curate.py) | One Gemini call: dedupe, section, rank, summarize, flag |
 | [src/images.py](src/images.py) | Keep source thumbnails; suppress on sensitive stories |
@@ -54,6 +56,7 @@ secrets in CI. See [.env.example](.env.example).
 | `GEMINI_API_KEY` | curation (Google AI Studio, free tier) |
 | `GUARDIAN_API_KEY` | Guardian world/business/sport/opinion |
 | `NYT_API_KEY` | NYT world/business |
+| `PERIGON_API_KEY` | Perigon world/business/markets (optional, free tier; skipped if unset) |
 | `NTFY_TOPIC` | morning push |
 | `PAGES_URL` | cache-buster + notification link (CI: set as a repo **variable**) |
 | `CURATE_MODEL` | optional model override (default `gemini-2.5-flash`) |
@@ -76,9 +79,10 @@ Pages serves `docs/` on `main` at `https://BenWassa.github.io/Hermes/`.
 - [ ] Get a Gemini API key — https://aistudio.google.com/apikey (free tier)
 - [ ] Get a Guardian API key — https://open-platform.theguardian.com/
 - [ ] Get an NYT API key — https://developer.nytimes.com/
+- [ ] (Optional) Get a Perigon API key — https://www.perigon.io/ (free tier; widens business/world coverage)
 - [ ] Pick an ntfy topic (hard to guess), install the ntfy iOS app, subscribe
 - [ ] Add repo **secrets**: `GEMINI_API_KEY`, `GUARDIAN_API_KEY`,
-      `NYT_API_KEY`, `NTFY_TOPIC`
+      `NYT_API_KEY`, `PERIGON_API_KEY` (optional), `NTFY_TOPIC`
 - [ ] Add repo **variable** `PAGES_URL` (e.g. `https://BenWassa.github.io/Hermes/`)
 - [ ] Enable GitHub Pages: Settings → Pages → source = `main`, folder = `/docs`
 - [ ] Verify the Toronto RSS URLs in [src/config.py](src/config.py) still resolve; swap any dead ones

--- a/src/config.py
+++ b/src/config.py
@@ -63,6 +63,32 @@ NYT_SECTIONS = {
     "business": "business",
 }
 
+# Perigon News API queries -> our section hint. Each entry is one request to the
+# /v1/all endpoint. Perigon aggregates thousands of outlets (FT, Reuters,
+# Bloomberg, etc.), which broadens the business and world pool well beyond the
+# Guardian/NYT pairing - the point being to actually guide a business reader.
+# Requests are deliberately few (free-tier friendly) and balanced by the curate
+# trimmer, so no single query crowds out the others. "category" accepts Perigon's
+# Google-derived content categories; multiple values OR together. Skipped
+# gracefully when PERIGON_API_KEY is unset.
+PERIGON_QUERIES = [
+    {
+        "label": "world",
+        "hint": "world",
+        "params": {"category": ["Politics", "General"], "country": ["us", "gb", "ca"]},
+    },
+    {
+        "label": "business",
+        "hint": "business",
+        "params": {"category": ["Business", "Finance"]},
+    },
+    {
+        "label": "markets",
+        "hint": "business",
+        "params": {"q": "markets OR economy OR earnings OR central bank", "category": ["Finance"]},
+    },
+]
+
 # Toronto local RSS feeds. A dead feed is skipped gracefully (never crashes the
 # run); verify these resolve and swap any that rot.
 TORONTO_RSS = [

--- a/src/fetch.py
+++ b/src/fetch.py
@@ -1,11 +1,12 @@
 """Task 2 (part 1) - Fetch.
 
-Pull raw stories from the Guardian API, the NYT Top Stories API, and Toronto
-RSS feeds. Each source is wrapped so a failure (missing key, dead feed, network
-error) logs a warning and returns an empty list rather than crashing the run.
+Pull raw stories from the Guardian API, the NYT Top Stories API, the Perigon
+News API, and Toronto RSS feeds. Each source is wrapped so a failure (missing
+key, dead feed, network error) logs a warning and returns an empty list rather
+than crashing the run.
 
 Each returned item is a source-native-ish dict carrying two helper keys the
-normalizer relies on: ``_src`` (guardian|nyt|rss) and ``_section_hint``.
+normalizer relies on: ``_src`` (guardian|nyt|perigon|rss) and ``_section_hint``.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ log = logging.getLogger("the-daily.fetch")
 
 GUARDIAN_URL = "https://content.guardianapis.com/search"
 NYT_URL = "https://api.nytimes.com/svc/topstories/v2/{section}.json"
+PERIGON_URL = "https://api.perigon.io/v1/all"
 
 _TIMEOUT = 20
 
@@ -84,6 +86,43 @@ def fetch_nyt() -> list[dict]:
     return items
 
 
+def fetch_perigon(size: int = 10) -> list[dict]:
+    """Perigon News API across the configured queries.
+
+    Perigon aggregates a much wider outlet set (FT, Reuters, Bloomberg, etc.)
+    than the Guardian/NYT pair, so it deepens the world and business pools.
+    Each configured query is one ``/v1/all`` request; a per-query failure logs a
+    warning and is skipped. Skipped entirely (with a warning) when the key is
+    missing, exactly like the other keyed sources.
+    """
+    key = os.environ.get("PERIGON_API_KEY")
+    if not key:
+        log.warning("PERIGON_API_KEY not set; skipping Perigon")
+        return []
+
+    items: list[dict] = []
+    for query in config.PERIGON_QUERIES:
+        try:
+            params: dict = {
+                "apiKey": key,
+                "size": size,
+                "sortBy": "date",
+                "language": "en",
+                "showReprints": "false",
+            }
+            params.update(query.get("params", {}))
+            resp = requests.get(PERIGON_URL, params=params, timeout=_TIMEOUT)
+            resp.raise_for_status()
+            results = resp.json().get("articles", [])
+            for r in results:
+                r["_src"] = "perigon"
+                r["_section_hint"] = query["hint"]
+            items.extend(results)
+        except Exception as exc:  # graceful per-query
+            log.warning("Perigon query %s failed: %s", query.get("label"), exc)
+    return items
+
+
 _RSS_HEADERS = {"User-Agent": "TheDaily/2.0 (+https://github.com/BenWassa/Hermes)"}
 
 
@@ -115,7 +154,7 @@ def fetch_toronto_rss() -> list[dict]:
 
 def fetch_all() -> list[dict]:
     """All sources concatenated into one raw list."""
-    return fetch_guardian() + fetch_nyt() + fetch_toronto_rss()
+    return fetch_guardian() + fetch_nyt() + fetch_perigon() + fetch_toronto_rss()
 
 
 if __name__ == "__main__":

--- a/src/normalize.py
+++ b/src/normalize.py
@@ -65,6 +65,24 @@ def _normalize_nyt(item: dict) -> dict:
     }
 
 
+def _normalize_perigon(item: dict) -> dict:
+    source = item.get("source") or {}
+    # Perigon's article source object carries a domain (e.g. "ft.com"); prefer a
+    # friendly name when present, otherwise show the domain without "www.".
+    name = source.get("name") or source.get("domain") or "Perigon"
+    if name.startswith("www."):
+        name = name[4:]
+    return {
+        "title": _clean(item.get("title")),
+        "description": _clean(item.get("description") or item.get("summary")),
+        "source": name,
+        "section_hint": item.get("_section_hint", "world"),
+        "pub_date": item.get("pubDate", "") or item.get("addDate", ""),
+        "image": item.get("imageUrl") or None,
+        "link": item.get("url", ""),
+    }
+
+
 def _normalize_rss(item: dict) -> dict:
     image = None
     # feedparser exposes media:thumbnail / media:content variously.
@@ -92,6 +110,7 @@ def _normalize_rss(item: dict) -> dict:
 _DISPATCH = {
     "guardian": _normalize_guardian,
     "nyt": _normalize_nyt,
+    "perigon": _normalize_perigon,
     "rss": _normalize_rss,
 }
 


### PR DESCRIPTION
Broadens the world/business pool beyond the Guardian + NYT pairing.
Perigon aggregates thousands of outlets (FT, Reuters, Bloomberg, etc.),
so the business desk reads like a professional's rather than one paper,
addressing the "can't just use the Guardian" concern in #4.

Follows the existing pluggable source pattern:
- config.PERIGON_QUERIES: world + business + markets queries -> section
  hints, balanced by the curate trimmer so no query crowds the others
- fetch.fetch_perigon(): one /v1/all request per query, graceful
  per-query failure, skipped entirely (with a warning) when the key is
  unset, exactly like Guardian/NYT
- normalize._normalize_perigon(): maps to the unified story schema
- wired into fetch_all(), the CI build env, .env.example, and README

Optional and free-tier friendly: PERIGON_API_KEY signup is the only
manual step; the pipeline runs unchanged without it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LaVA3Unwfj8Lz61ZW16eFv